### PR TITLE
Remover obrigatoriedade do campo de "Complemento"

### DIFF
--- a/src/view/Cart/components/SideBar/logic/index.ts
+++ b/src/view/Cart/components/SideBar/logic/index.ts
@@ -28,7 +28,7 @@ const useSidebar = () => {
   const isSubway = currentOption === 'Metrô'
 
   const ignorableValuesMapper = {
-    Endereço: ['station', 'observation'],
+    Endereço: ['station', 'observation', 'complement'],
     Metrô: ['street', 'neighborhood', 'number', 'complement', 'observation'],
     Retirar: [
       'station',


### PR DESCRIPTION
###### Description:
  Nessa issue é removida a obrigatoriedade do campo de complemento.
  
  Oque foi feito:

  - adicionando `complement` na lista de `ignorableValuesMapper` do `Endereço`.